### PR TITLE
Name of ROS2 Topics and msg type

### DIFF
--- a/software/Embedded/RPI/IMU_DEPTH.py
+++ b/software/Embedded/RPI/IMU_DEPTH.py
@@ -20,8 +20,8 @@ class CANReceiverNode(Node):
         super().__init__('can_receiver_node')
 
         # Publishers
-        self.imu_publisher = self.create_publisher(Imu, 'ROV/IMU', 10)
-        self.depth_publisher = self.create_publisher(Float32, 'ROV/Depth', 10)
+        self.imu_publisher = self.create_publisher(Imu, 'ROV/imu', 10)
+        self.depth_publisher = self.create_publisher(Float32, 'ROV/depth', 10)
 
         # Set up CAN bus
         self.bus = can.interface.Bus(channel='can0', bustype='socketcan')

--- a/software/Embedded/RPI/can_ros2_bridge.py
+++ b/software/Embedded/RPI/can_ros2_bridge.py
@@ -3,7 +3,7 @@ import rclpy
 from rclpy.node import Node
 import can
 import struct
-from std_msgs.msg import Float64MultiArray, String, Bool, Int32, Int32MultiArray
+from std_msgs.msg import Float64MultiArray, String, Bool, Int32, Int8, Int32MultiArray
 
 # CAN IDs for devices
 THRUSTERS_ID = 0x100
@@ -36,7 +36,7 @@ class CANBridge(Node):
         self.create_subscription(Int32MultiArray, '/ROV/thrusters', self.thruster_callback, 10)
         self.create_subscription(Bool, '/ROV/gripper_l', self.gripper_l_callback, 10)
         self.create_subscription(Bool, '/ROV/gripper_r', self.gripper_r_callback, 10)
-        self.create_subscription(Int32, '/ROV/pump', self.pump_callback, 10)
+        self.create_subscription(Int8, '/ROV/pump', self.pump_callback, 10)
         self.create_subscription(String, '/Commands', self.command_callback, 10)
 
 


### PR DESCRIPTION
Fixing the ROS2 topics' names for better handling and compatibility; moreover, changing the type of pump msg from int32 to int8.